### PR TITLE
CircleCIのdeployジョブの移行

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           name: php test
           command: vendor/bin/phpunit
 
-  deploy:
+  deploy_old:
     docker:
       - image: circleci/php:7.3-node-browsers
     environment:
@@ -91,7 +91,7 @@ jobs:
             --deployment-group-name laravel-ci \
             --s3-location bucket=${AWS_S3_BUCKET_NAME},key=laravel-ci.zip,bundleType=zip
 
-  deploy_tmp:
+  deploy:
     docker:
       - image: circleci/php:7.3-node-browsers
     steps:
@@ -111,13 +111,6 @@ workflows:
     jobs:
       - build
       - deploy:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - master
-      - deploy_tmp:
           requires:
             - build
           filters:


### PR DESCRIPTION
# WHAT

- CircleCIでのデプロイをしないように編集
- `deploy_old` に変更しているがこれは動作しない。敢えて残してあるだけ
